### PR TITLE
Remove "?response_id" from giphy urls

### DIFF
--- a/sirbot/pythondev/slack.py
+++ b/sirbot/pythondev/slack.py
@@ -318,6 +318,7 @@ class SlackEndpoint:
 
         if command.text:
             urls = await giphy.search(command.text)
+            urls = [url.split('?')[0] for url in urls]
 
             att = Attachment(
                 title='You searched for `{}`'.format(command.text),


### PR DESCRIPTION
Giphy added a response_id parameters in the urls return by the search.
This was making the urls in the payload be bigger the slack limit of
2000 characters