### PR TITLE
Fixes #34 - formatting dm messages fix

### DIFF
--- a/sirbot/pythondev/slack.py
+++ b/sirbot/pythondev/slack.py
@@ -167,9 +167,10 @@ class SlackEndpoint:
             user_count = await candy.add(user, count)
             msg = response.clone()
             msg.to = slack_user
-            msg.text = '<@{sender}> gave you {count} {trigger}.' \
-                       ' You now have {user_count} {trigger}.'
-            msg.text.format(
+
+            text_message = '<@{sender}> gave you {count} {trigger}.' \
+                           ' You now have {user_count} {trigger}.'
+            msg.text = text_message.format(
                 sender=message.frm.id,
                 count=count,
                 trigger=self.config['candy']['trigger'],


### PR DESCRIPTION
Pretty straight forward fix, the `.format` method returns the formatted string vs formatting in place. Looks like just a simple oversight.